### PR TITLE
Fixing Renderisation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     compileOnly("org.jetbrains.dokka:dokka-core:$dokkaVersion")
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.dokka:dokka-base:$dokkaVersion")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.1")
 
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.dokka:dokka-test-api:$dokkaVersion")

--- a/scripts/publish.gradle
+++ b/scripts/publish.gradle
@@ -10,7 +10,7 @@ ext["signing.keyId"] = ''
 ext["signing.password"] = ''
 ext["signing.secretKeyRingFile"] = ''
 
-def PUBLISH_VERSION = "0.1.7"
+def PUBLISH_VERSION = "0.1.8"
 def PUBLISH_GROUP_ID = "io.getstream"
 def PUBLISH_ARTIFACT_ID = "dokkasaurus"
 

--- a/src/main/kotlin/io/getstream/dokkasaurus/utils/StringExtensions.kt
+++ b/src/main/kotlin/io/getstream/dokkasaurus/utils/StringExtensions.kt
@@ -1,48 +1,5 @@
 package io.getstream.dokkasaurus.utils
 
-internal fun String.scapeTags(): String {
-    var insideTagBegin = false
-    var insideTagEnd = false
-
-
-    return foldIndexed("") { index, acc, char ->
-        when {
-            !insideTagBegin && char == '<' -> {
-                insideTagBegin = true
-
-                "$acc`$char"
-            }
-
-            insideTagBegin && char == '<' -> "$acc$char"
-
-            insideTagBegin && char != '<' -> {
-                insideTagBegin = false
-                "$acc`$char"
-            }
-
-            !insideTagEnd && char == '>' ->
-                if (index == length - 1) {
-                    "$acc`$char`"
-                } else {
-                    insideTagEnd = true
-                    "$acc`$char"
-                }
-
-            //The end was reached inside tag end
-            insideTagEnd && index == length - 1 -> "$acc$char`"
-
-            insideTagEnd && char == '>' -> "$acc$char"
-
-            insideTagEnd && char != '>' -> {
-                insideTagBegin = false
-                "$acc$char`"
-            }
-
-            else -> "$acc$char"
-        }
-    }
-}
-
 internal fun String.simpleScapeTags(): String {
     return this.replace("<", "&lt;").replace(">", "&gt;")
 }

--- a/src/main/kotlin/io/getstream/dokkasaurus/utils/gfmTemplating.kt
+++ b/src/main/kotlin/io/getstream/dokkasaurus/utils/gfmTemplating.kt
@@ -1,0 +1,16 @@
+package io.getstream.dokkasaurus.utils
+
+import org.jetbrains.dokka.links.DRI
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS
+
+@JsonTypeInfo(use = CLASS)
+sealed class Command {
+    companion object {
+        fun Appendable.templateCommand(command: Command, content: Appendable.() -> Unit) {
+            content()
+        }
+    }
+}
+
+class ResolveLinkCommands(val dri: DRI) : Command()


### PR DESCRIPTION
Fixing renderization of pages. 

- `@SinceKotlin` was breaking tables. Fixed now.
-  Some functions were not written with a line break at the end. Fixed now.
- Strikethrough was not correctly rendered. This is removed for now. 

Changed in the pom: dokkasaurus instead of Dokkasaurus