### PR TITLE
Fix publishing or jar artifacts

### DIFF
--- a/scripts/publish.gradle
+++ b/scripts/publish.gradle
@@ -67,7 +67,7 @@ afterEvaluate {
                 groupId PUBLISH_GROUP_ID
                 artifactId PUBLISH_ARTIFACT_ID
                 version PUBLISH_VERSION
-                artifact("${buildDir}/libs/dokkasaurus-${version}.jar")
+                from components.java 
                 artifact javadocJar
                 artifact sourcesJar
 


### PR DESCRIPTION
By using `from components.java` instead of the previous artifact, the needed dependencies are included on the pom file